### PR TITLE
Initialize `mSymbols` to NULL if symbols of referenced `HumbleStackTrace` is empty

### DIFF
--- a/humble-video-native/src/main/gnu/src/io/humble/ferry/HumbleException.cpp
+++ b/humble-video-native/src/main/gnu/src/io/humble/ferry/HumbleException.cpp
@@ -60,6 +60,8 @@ HumbleStackTrace::HumbleStackTrace(const HumbleStackTrace & e) {
     if (mSymbols)
       memcpy(mSymbols, e.mSymbols, mNumFrames);
     // if there was a malloc error, just let it pass.
+  } else {
+    mSymbols = 0;
   }
 }
 


### PR DESCRIPTION
If `mSymbols` field of passed `HumbleStackTrace` instance is empty (on **Windows**), `mSymbols` field of target `HumbleStackTrace` instance is not set to NULL in its constructor. In this case, if `HumbleStackTrace` instance is allocated on stack (for example by just declaring it like `HumbleStackTrace hst(targetHst);` as variable), its `mSymbols` field is not set to NULL so it might have a random content. Therefore while it is being destroyed, in its destructor, it might try to free an invalid memory location by `free(mSymbols)` call.

I have found this issue while investigating a JVM crash which is able to be reproduced with this simple code:
``` java
import io.humble.video.Demuxer;
import io.humble.video.KeyValueBag;
import io.humble.video.VideoJNI;
import io.humble.video.customio.HumbleIO;
import io.humble.video.customio.IURLProtocolHandler;

public class HumbleVideoCrashDemo {

    private static final int ITERATION_COUNT = 100000;
    
    public static void main(String[] args) throws NoSuchFieldException, SecurityException {
        System.out.println("Initializing ...");
        
        VideoJNI.noop();
        
        System.out.println("Demo has just started ...");

        for (int i = 0; i < ITERATION_COUNT; i++) {
            if (i % (ITERATION_COUNT / 10) == 0) {
                System.out.println("%" + ((i * 100) / ITERATION_COUNT) + " completed ...");
            }
            Demuxer source = null;
            try {
                String url = HumbleIO.map(new DummyURLProtocolHandler());
            
                KeyValueBag kv = KeyValueBag.make();
                kv.setValue("abc", "123");

                source = Demuxer.make();
                
                source.open(url, null, false, true, kv, null);
            } catch (Exception e1) {
                try {
                    if (source != null && source.getState().equals(Demuxer.State.STATE_OPENED)) {
                        source.close();
                    }    
                } catch (Exception e2) {
                }
            }
        }
        
        System.out.println("Demo has finished successfully!");
    }
  
    private static class DummyURLProtocolHandler implements IURLProtocolHandler {
      
        private int counter = 0;
      
        @Override
        public int write(byte[] buf, int size) {
            return -1;
        }
      
        @Override
        public long seek(long offset, int whence) {
            return -1;
        }
      
        @Override
        public int read(byte[] buf, int size) {
            if (counter++ < 3) {
                return size;
            } else {
                return -1;
            }    
        }
      
        @Override
        public int open(String url, int flags) {
            return 0;
        }
      
        @Override
        public boolean isStreamed(String url, int flags) {
            return true;
        }
      
        @Override
        public int close() {
            return 0;
        }
      
    }

}
``` 

The problematic case I have mentioned above happens at `VS_THROW` macro in `Logger.h` (https://github.com/artclarke/humble-video/blob/a1d27743154d62e0eeccc8711a88d101766cb32d/humble-video-native/src/main/gnu/src/io/humble/ferry/Logger.h#L218). 

`VS_THROW` is called from many places in the code base like these: `VS_THROW(HumbleInvalidArgument("..."));`, `VS_THROW(HumbleRuntimeError("cannot add sources after opening graph"));`, `VS_THROW(HumbleIOException(...));`, ... 

After, I have fixed this issue, the test never fails.